### PR TITLE
Fixed and reverted the frag suit to its original design

### DIFF
--- a/Defs/ThingDefs/Apparel_Various.xml
+++ b/Defs/ThingDefs/Apparel_Various.xml
@@ -436,7 +436,7 @@
   <ThingDef ParentName="ApparelMakeableBase">
     <defName>CE_Armor_FragSuit</defName>
     <label>frag suit</label>
-    <description>A thick overall composed of soft armor fabric layers, akin to an explosives disposal suit but lighter. Protects limbs from shrapnel and fire, includes gloves and boots.</description>
+    <description>A bodysuit padded with armor fabrics, worn under plate carrier for protection of limbs against shrapnel. Comes with a pair and boots and gloves.</description>
     <graphicData>
       <texPath>Things/Apparel/FragSuit/FragSuit</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -461,16 +461,16 @@
       <li>ApparelArmor</li>
     </thingCategories>
     <statBases>
-      <MaxHitPoints>300</MaxHitPoints>
+      <MaxHitPoints>200</MaxHitPoints>
       <WorkToMake>16000</WorkToMake>
       <Bulk>7</Bulk>
       <WornBulk>3.5</WornBulk>
-      <Mass>5.5</Mass>
+      <Mass>5.0</Mass>
       <Flammability>0.6</Flammability>
       <StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
       <ArmorRating_Sharp>1.5</ArmorRating_Sharp>
       <ArmorRating_Blunt>1.0</ArmorRating_Blunt>
-      <ArmorRating_Heat>0.7</ArmorRating_Heat>
+      <ArmorRating_Heat>0.1</ArmorRating_Heat>
       <StuffEffectMultiplierInsulation_Cold>0.8</StuffEffectMultiplierInsulation_Cold>
       <StuffEffectMultiplierInsulation_Heat>0.0</StuffEffectMultiplierInsulation_Heat>
       <EquipDelay>5</EquipDelay>
@@ -487,7 +487,7 @@
       </bodyPartGroups>
       <wornGraphicPath>Things/Apparel/FragSuit/FragSuit</wornGraphicPath>
       <layers>
-        <li>Shell</li>
+        <li>OnSkin</li>
       </layers>
       <tags>
         <li>IndustrialMilitaryBasic</li>


### PR DESCRIPTION
Frag suits are not coats in real life and are worn under plate carriers.
The intended design for the frag suit is having an armored apparel worn on the skin layer (but is bulky and heavy to compensate for it being armored to give the player something to consider and think about while designing apparel compositions) which is in the industrial era, can be layered with other armor pieces and coupled with Power Armor.
Let alone that the first design has been approved as it was and changing the occupying layer not only does not make sense, it also makes the item useless and redundant because there are other apparel options on the outer layer which fulfill the "outer layer armored clothing" pretty well.

Real life Frag suit:
![image](https://user-images.githubusercontent.com/56392968/167084996-c0af6672-e01f-4867-b602-1498e86471ee.png)
As it is obvious in the image, frag suits are worn under plate carriers resulting in a skin layer clothing in-game.

If it is decided that an armored outer layer clothing is needed, another appropriate piece of apparel can be added to the mod to complete the line-up which is again redundant in my opinion as mentioned above. This mod has been made with necessities in mind, only apparel that fill a niche.