### PR TITLE
Adjust ballistic goggle crafting recipe

### DIFF
--- a/Defs/ThingDefs/Apparel_Headgear.xml
+++ b/Defs/ThingDefs/Apparel_Headgear.xml
@@ -125,8 +125,8 @@
     <techLevel>Industrial</techLevel>
     <generateCommonality>0.25</generateCommonality>
     <costList>
-      <Steel>30</Steel>
-      <Chemfuel>40</Chemfuel>
+      <Steel>10</Steel>
+      <Chemfuel>15</Chemfuel>
     </costList>
     <statBases>
       <MaxHitPoints>100</MaxHitPoints>

--- a/Defs/ThingDefs/Apparel_Headgear.xml
+++ b/Defs/ThingDefs/Apparel_Headgear.xml
@@ -18,7 +18,7 @@
       <li>Fabric</li>
     </stuffCategories>
     <statBases>
-      <MaxHitPoints>75</MaxHitPoints>
+      <MaxHitPoints>100</MaxHitPoints>
       <WorkToMake>2200</WorkToMake>
       <Mass>0.35</Mass>
       <Bulk>0.5</Bulk>
@@ -129,7 +129,7 @@
       <Chemfuel>15</Chemfuel>
     </costList>
     <statBases>
-      <MaxHitPoints>100</MaxHitPoints>
+      <MaxHitPoints>75</MaxHitPoints>
       <WorkToMake>5500</WorkToMake>
       <Mass>0.2</Mass>
       <Bulk>0.5</Bulk>

--- a/Defs/ThingDefs/Apparel_Headgear.xml
+++ b/Defs/ThingDefs/Apparel_Headgear.xml
@@ -18,7 +18,7 @@
       <li>Fabric</li>
     </stuffCategories>
     <statBases>
-      <MaxHitPoints>100</MaxHitPoints>
+      <MaxHitPoints>75</MaxHitPoints>
       <WorkToMake>2200</WorkToMake>
       <Mass>0.35</Mass>
       <Bulk>0.5</Bulk>


### PR DESCRIPTION
What it says on the tin, decreased the material cost of the ballistic goggles to a more appropriate amount of steel and chemfuel. Adjusted the HP of the goggles to resemble them being fragile and useless just like IRL.