### PR TITLE
Fix poncho's apparel tag

### DIFF
--- a/Defs/ThingDefs/Apparel_Various.xml
+++ b/Defs/ThingDefs/Apparel_Various.xml
@@ -302,8 +302,7 @@
         <li>Shell</li>
       </layers>
       <tags>
-        <li>IndustrialBasic</li>
-        <li>Western</li>
+        <li>IndustrialAdvanced</li>
       </tags>
       <defaultOutfitTags>
         <li>Worker</li>


### PR DESCRIPTION
What it says on the tin.

Just to stop the starting crashlanded colonists from spawning with ponchos right off the bat.