### PR TITLE
Adjust poncho's mass and gambeson's HP

### DIFF
--- a/Defs/ThingDefs/Apparel_Various.xml
+++ b/Defs/ThingDefs/Apparel_Various.xml
@@ -274,7 +274,7 @@
     <statBases>
       <MaxHitPoints>200</MaxHitPoints>
       <WorkToMake>10000</WorkToMake>
-      <Mass>2.0</Mass>
+      <Mass>2.5</Mass>
       <Bulk>8.5</Bulk>
       <WornBulk>2.5</WornBulk>
       <StuffEffectMultiplierArmor>6</StuffEffectMultiplierArmor>

--- a/Defs/ThingDefs/Apparel_Various.xml
+++ b/Defs/ThingDefs/Apparel_Various.xml
@@ -20,7 +20,7 @@
       <li>Fabric</li>
     </stuffCategories>
     <statBases>
-      <MaxHitPoints>120</MaxHitPoints>
+      <MaxHitPoints>150</MaxHitPoints>
       <WorkToMake>6000</WorkToMake>
       <Mass>3.0</Mass>
       <Bulk>8</Bulk>


### PR DESCRIPTION
Poncho requires more materials to craft and covers mostly the same as the duster, hence the needed mass value increase of 0.5kg for balance reasons.

Gambeson covers the whole body and absorbs a lot of hits, an increase of its HP from 120 to 150 is only reasonable.