### PR TITLE
Remove the IndustrialMilitaryBasic tag from large backpacks

### DIFF
--- a/1.5/Defs/ThingDefs/Apparel_Carrying.xml
+++ b/1.5/Defs/ThingDefs/Apparel_Carrying.xml
@@ -48,7 +48,6 @@
 				<li>Backpack</li>
 			</layers>
 			<tags>
-				<li>IndustrialMilitaryBasic</li>
 				<li>IndustrialMilitaryAdvanced</li>
 			</tags>
 			<defaultOutfitTags>


### PR DESCRIPTION
## Changes

Removed the IndustrialMilitaryBasic tag from large backpacks.

## Reasoning

For a piece of apparel that requires machining - a straight upgrade from the normal backpack, mind you - it is way too common, often appearing on pawns which are supposed to be quite poor. With how utility/backpack items work, they don't get tainted either, meaning finding one on the battlefield is just a free upgrade. If your pawns already have large backpacks then it's just free wealth, since they can't be tainted and have a slightly higher base value.
Base Combat Extended is already balanced with normal backpacks + tactical vests in mind, handing out these upgrades as freebies doesn't make much sense.

Other advanced industrial armors which have high research requirements, like the gorka suit, are tagged similarly. Most high level industrial upgrades to low level industrial gear are tagged with IndustrialMilitaryAdvanced.

Pawn kinds which have the IndustrialMilitaryAdvanced tag generally either directly have the IndustrialMilitaryBasic tag or inherit it from a base pawn. The normal backpack from base Combat Extended has both tags, so this change will take the large backpacks away from pawns that generally don't need/shouldn't have them while still allowing higher tier pawns to have access to both options.

![image](https://github.com/user-attachments/assets/6924f7ed-d12d-4234-8cce-5b2f0cb13a8d)

## Testing

Check tests you have performed:
- [ ] Compiles without warnings - This change does not require a recompile.
- [X] Game runs without errors
- [X] Playtested a colony (specify how long) - Messed around with spawning clusters of a variety of pawns, changes didn't seem to have any negative effects on any pawns.